### PR TITLE
Implement START and END blocks for IMPETUS language

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git checkout:*)",
+      "Bash(git add:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/Canvas.Drawing.cs
+++ b/Canvas.Drawing.cs
@@ -139,18 +139,55 @@ namespace BlockCanvas {
 
             using var path = RoundedRect(rect, radius);
             var selected = selection.Contains(n);
-            using var fill = new LinearGradientBrush(rect, Color.FromArgb(58, 62, 70), Color.FromArgb(44, 47, 53), LinearGradientMode.Vertical);
-            using var border = new Pen(selected ? Color.FromArgb(120, 190, 255) : Color.FromArgb(85, 90, 100), selected ? 2.5f : 1.5f);
+            
+            // Special colors for START and END blocks
+            LinearGradientBrush fill;
+            Pen border;
+            
+            switch (n.Type) {
+                case NodeType.Start:
+                    fill = new LinearGradientBrush(rect, Color.FromArgb(58, 120, 58), Color.FromArgb(44, 80, 44), LinearGradientMode.Vertical);
+                    border = new Pen(selected ? Color.FromArgb(120, 255, 120) : Color.FromArgb(85, 150, 85), selected ? 2.5f : 1.5f);
+                    break;
+                case NodeType.End:
+                    fill = new LinearGradientBrush(rect, Color.FromArgb(120, 58, 58), Color.FromArgb(80, 44, 44), LinearGradientMode.Vertical);
+                    border = new Pen(selected ? Color.FromArgb(255, 120, 120) : Color.FromArgb(150, 85, 85), selected ? 2.5f : 1.5f);
+                    break;
+                default:
+                    fill = new LinearGradientBrush(rect, Color.FromArgb(58, 62, 70), Color.FromArgb(44, 47, 53), LinearGradientMode.Vertical);
+                    border = new Pen(selected ? Color.FromArgb(120, 190, 255) : Color.FromArgb(85, 90, 100), selected ? 2.5f : 1.5f);
+                    break;
+            }
 
             g.FillPath(fill, path);
             g.DrawPath(border, path);
+            fill.Dispose();
+            border.Dispose();
 
             // Title bar
             var titleRect = new RectangleF(rect.X, rect.Y, rect.Width, n.TitleH);
-            using var titleBrush = new SolidBrush(Color.FromArgb(70, 74, 82));
-            using var titleBorder = new Pen(Color.FromArgb(90, 95, 105), 1);
+            SolidBrush titleBrush;
+            Pen titleBorder;
+            
+            switch (n.Type) {
+                case NodeType.Start:
+                    titleBrush = new SolidBrush(Color.FromArgb(70, 120, 70));
+                    titleBorder = new Pen(Color.FromArgb(90, 150, 90), 1);
+                    break;
+                case NodeType.End:
+                    titleBrush = new SolidBrush(Color.FromArgb(120, 70, 70));
+                    titleBorder = new Pen(Color.FromArgb(150, 90, 90), 1);
+                    break;
+                default:
+                    titleBrush = new SolidBrush(Color.FromArgb(70, 74, 82));
+                    titleBorder = new Pen(Color.FromArgb(90, 95, 105), 1);
+                    break;
+            }
+            
             g.FillRectangle(titleBrush, titleRect);
             g.DrawLine(titleBorder, titleRect.Left, titleRect.Bottom, titleRect.Right, titleRect.Bottom);
+            titleBrush.Dispose();
+            titleBorder.Dispose();
 
             using var textBrush = new SolidBrush(Color.White);
             var sfTitle = new StringFormat {

--- a/Canvas.InputHandling.cs
+++ b/Canvas.InputHandling.cs
@@ -191,8 +191,15 @@ namespace BlockCanvas {
 
 
                     menu.Items.Add(new ToolStripSeparator());
-                    menu.Items.Add("Add Input Port", null, (_, __) => AddInputPort(hitNode));
-                    menu.Items.Add("Add Output Port", null, (_, __) => AddOutputPort(hitNode));
+                    var addInputItem = new ToolStripMenuItem("Add Input Port", null, (_, __) => AddInputPort(hitNode));
+                    var addOutputItem = new ToolStripMenuItem("Add Output Port", null, (_, __) => AddOutputPort(hitNode));
+                    
+                    // Disable inappropriate port operations for START/END blocks
+                    if (hitNode.Type == NodeType.Start) addInputItem.Enabled = false;
+                    if (hitNode.Type == NodeType.End) addOutputItem.Enabled = false;
+                    
+                    menu.Items.Add(addInputItem);
+                    menu.Items.Add(addOutputItem);
 
                     var rmIn = new ToolStripMenuItem("Remove Input Port");
                     for (int i = 0; i < hitNode.Inputs.Count; i++) {
@@ -229,14 +236,16 @@ namespace BlockCanvas {
                     // Blank-canvas context menu (no demo entries)
                     var menu = new ContextMenuStrip();
 
-                    void AddAt(string title) {
+                    void AddAt(string title, NodeType nodeType = NodeType.Regular) {
                         var world = ScreenToWorld(e.Location);
                         var pos = new PointF(world.X - 30, world.Y - 16);
-                        var n = new Node(title, pos, createDefaultPorts: false);
+                        var n = new Node(title, pos, createDefaultPorts: true, nodeType);
                         AddNode(n);
                     }
 
                     menu.Items.Add("Add Block Here", null, (_, __) => AddAt("Block"));
+                    menu.Items.Add("Add START Block", null, (_, __) => AddAt("START", NodeType.Start));
+                    menu.Items.Add("Add END Block", null, (_, __) => AddAt("END", NodeType.End));
 
                     if (selection.Count > 0 && selection.Any(n => !n.IsProxy)) {
                         menu.Items.Add(new ToolStripSeparator());

--- a/Canvas.InputHandling.cs
+++ b/Canvas.InputHandling.cs
@@ -19,7 +19,14 @@ namespace BlockCanvas {
             // Double-click a node => dive in (world coords)
             var world = ScreenToWorld(e.Location);
             Node? hitNode = current.Nodes.LastOrDefault(n => !n.IsProxy && n.HitBody(world));
-            if (hitNode != null) ZoomInto(hitNode);
+            if (hitNode != null) {
+                // Don't allow zooming into START and END blocks
+                if (hitNode.Type == NodeType.Start || hitNode.Type == NodeType.End) {
+                    System.Media.SystemSounds.Beep.Play();
+                    return;
+                }
+                ZoomInto(hitNode);
+            }
         }
 
         private void OnKeyDown(object? sender, KeyEventArgs e) {

--- a/Canvas.Serialization.cs
+++ b/Canvas.Serialization.cs
@@ -27,6 +27,7 @@ namespace BlockCanvas {
                     IsProxy = n.IsProxy,
                     ProxyIsInlet = n.ProxyIsInlet,
                     ProxyIndex = n.ProxyIndex,
+                    Type = n.Type.ToString(),
                     Inputs = n.Inputs.Select(p => new PortDef { Name = p.Name, Type = p.TypeName }).ToList(),
                     Outputs = n.Outputs.Select(p => new PortDef { Name = p.Name, Type = p.TypeName }).ToList(),
                     Inner = n.Inner != null ? ToDto(n.Inner) : null
@@ -48,7 +49,8 @@ namespace BlockCanvas {
             var idMap = new Dictionary<string, Node>();
 
             foreach (var nDto in dto.Nodes) {
-                var n = new Node(nDto.Title, new PointF(nDto.X, nDto.Y), createDefaultPorts: false) {
+                var nodeType = Enum.TryParse<NodeType>(nDto.Type, out var parsedType) ? parsedType : NodeType.Regular;
+                var n = new Node(nDto.Title, new PointF(nDto.X, nDto.Y), createDefaultPorts: false, nodeType) {
                     Id = string.IsNullOrWhiteSpace(nDto.Id) ? Guid.NewGuid().ToString("N") : nDto.Id,
                     IsProxy = nDto.IsProxy,
                     ProxyIsInlet = nDto.ProxyIsInlet,

--- a/JsonDTO.cs
+++ b/JsonDTO.cs
@@ -37,6 +37,8 @@ namespace BlockCanvas {
         [JsonPropertyName("proxyIsInlet")] public bool ProxyIsInlet { get; set; }
         [JsonPropertyName("proxyIndex")] public int ProxyIndex { get; set; }
 
+        [JsonPropertyName("type")] public string Type { get; set; } = "Regular";
+
         [JsonPropertyName("inputs")] public List<PortDef> Inputs { get; set; } = new();
         [JsonPropertyName("outputs")] public List<PortDef> Outputs { get; set; } = new();
 


### PR DESCRIPTION
## Summary
- Implemented START and END blocks as specified in ImpetusSpec.md
- START blocks provide infinite output ports for program initiation
- END blocks provide infinite input ports for program termination
- Added distinctive visual styling (green for START, red for END)

## Test plan
- [x] Create START block from context menu
- [x] Create END block from context menu  
- [x] Add/remove ports on START/END blocks
- [x] Verify visual styling differences
- [x] Test serialization/deserialization of block types

🤖 Generated with [Claude Code](https://claude.ai/code)